### PR TITLE
Fixed conversion status update that was not working when using async conversion with `collective.documentviewer`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changelog
 - Fixed conversion status update that was not working when using async conversion
   with `collective.documentviewer`.
   [gbastien]
-- Display a action the `View preview` when a preview is available.
+- Display action `View preview` when a preview is available.
   [gbastien]
 
 2.19 (2023-08-24)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,11 @@ Changelog
 2.20 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Fixed conversion status update that was not working when using async conversion
+  with `collective.documentviewer`.
+  [gbastien]
+- Display a action the `View preview` when a preview is available.
+  [gbastien]
 
 2.19 (2023-08-24)
 -----------------

--- a/src/imio/annex/configure.zcml
+++ b/src/imio/annex/configure.zcml
@@ -49,6 +49,13 @@
     replacement=".patch.converter_call"
     preserveOriginal="true" />
 
+  <monkey:patch
+    description="Ensure that an event is triggered before the document conversion"
+    class="collective.documentviewer.async.JobRunner"
+    original="queue_it"
+    replacement=".patch.jobrunner_queue_it"
+    preserveOriginal="true" />
+
   <!-- behaviors -->
   <plone:behavior zcml:condition="installed collective.dms.scanbehavior"
        title="Scan metadata (fields to_sign/signed hidden)"

--- a/src/imio/annex/content/annex.py
+++ b/src/imio/annex/content/annex.py
@@ -73,6 +73,10 @@ class Annex(File):
             res = infos.show_download(element)
         return res
 
+    def show_preview(self):
+        """Condition to show the "Preview" action."""
+        return self.aq_parent.categorized_elements[self.UID()]['preview_status'] == 'converted'
+
 
 class AnnexSchemaPolicy(DexteritySchemaPolicy):
     """Schema Policy for Annex"""

--- a/src/imio/annex/patch.py
+++ b/src/imio/annex/patch.py
@@ -7,6 +7,7 @@ Created by mpeeters
 :license: GPL, see LICENCE.txt for more details.
 """
 
+from collective.documentviewer.async import JobRunner
 from collective.documentviewer.convert import Converter
 from imio.annex.events import ConversionStartedEvent
 from zope.event import notify
@@ -15,3 +16,8 @@ from zope.event import notify
 def converter_call(self, *args, **kwargs):
     notify(ConversionStartedEvent(self.context))
     return Converter._old___call__(self, *args, **kwargs)
+
+
+def jobrunner_queue_it(self):
+    JobRunner._old_queue_it(self)
+    notify(ConversionStartedEvent(self.object))

--- a/src/imio/annex/profiles.zcml
+++ b/src/imio/annex/profiles.zcml
@@ -35,7 +35,7 @@
       destination="1001"
       profile="imio.annex:default">
     <genericsetup:upgradeDepends
-        title="Adapt annex portal_type condition_expr"
+        title="Adapt annex portal_type condition_expr and new action 'View preview'"
         import_steps="typeinfo" />
   </genericsetup:upgradeSteps>
 

--- a/src/imio/annex/profiles/default/types/annex.xml
+++ b/src/imio/annex/profiles/default/types/annex.xml
@@ -44,6 +44,11 @@
     url_expr="string:${object/absolute_url}/view" visible="True">
   <permission value="Manage portal"/>
  </action>
+ <action title="View preview" action_id="view_preview" category="object_buttons" condition_expr="python:object.show_preview()"
+    description="" icon_expr="string:${portal_url}/file_icon.png" link_target="_blank"
+    url_expr="string:${object/absolute_url}/documentviewer#document/#/p1" visible="True">
+  <permission value="View"/>
+ </action>
  <action title="Download" action_id="download" category="object_buttons" condition_expr="python:object.show_download()"
     description="" icon_expr="string:${portal_url}/download_icon.png" link_target="_blank"
     url_expr="string:${object/absolute_url}/@@download" visible="True">


### PR DESCRIPTION
Display a action the `View preview` when a preview is available.
See #PM-4064